### PR TITLE
set deployment target

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -19,8 +19,9 @@ f5m_configure() {
     -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_FIND_ROOT_PATH="/Library/Input Methods/Fcitx5.app/Contents" \
-    -DCMAKE_OSX_ARCHITECTURES=$ARCH "$@" \
-    -DCMAKE_OSX_DEPLOYMENT_TARGET=11
+    -DCMAKE_OSX_ARCHITECTURES=$ARCH \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=11 \
+    "$@"
 }
 
 f5m_build() {

--- a/common.sh
+++ b/common.sh
@@ -19,7 +19,8 @@ f5m_configure() {
     -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_FIND_ROOT_PATH="/Library/Input Methods/Fcitx5.app/Contents" \
-    -DCMAKE_OSX_ARCHITECTURES=$ARCH "$@"
+    -DCMAKE_OSX_ARCHITECTURES=$ARCH "$@" \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=11
 }
 
 f5m_build() {

--- a/scripts/glib.sh
+++ b/scripts/glib.sh
@@ -11,6 +11,7 @@ sed -i '' "/^libintl_deps = \[\]/,/^glib_conf.set('HAVE_BIND_TEXTDOMAIN_CODESET'
  " meson.build
 
 SETUP_ARGS=(
+  --native-file=../scripts/meson-native-x86_64.ini
   --buildtype=release
   --prefix=$INSTALL_PREFIX
   -Dtests=false

--- a/scripts/json-glib.sh
+++ b/scripts/json-glib.sh
@@ -4,6 +4,7 @@ PKGNAME=json-glib
 cd $PKGNAME
 
 SETUP_ARGS=(
+  --native-file=../scripts/meson-native-x86_64.ini
   --buildtype=release
   --prefix=$INSTALL_PREFIX
   --default-library=static

--- a/scripts/libxkbcommon.sh
+++ b/scripts/libxkbcommon.sh
@@ -3,6 +3,7 @@ set -e
 cd libxkbcommon
 
 SETUP_ARGS=(
+  --native-file=../scripts/meson-native-x86_64.ini
   --buildtype=release
   --prefix=$INSTALL_PREFIX
   --default-library=static

--- a/scripts/meson-cross-arm64.ini
+++ b/scripts/meson-cross-arm64.ini
@@ -10,12 +10,12 @@ pkg-config = 'pkg-config'
 pkg_config_libdir = '/tmp/fcitx5/lib/pkgconfig'
 
 [built-in options]
-c_args = ['-arch', 'arm64']
-cpp_args = ['-arch', 'arm64']
-objc_args = ['-arch', 'arm64']
-c_link_args = ['-arch', 'arm64']
-cpp_link_args = ['-arch', 'arm64']
-objc_link_args = ['-arch', 'arm64']
+c_args = ['-arch', 'arm64', '-mmacosx-version-min=11']
+cpp_args = ['-arch', 'arm64', '-mmacosx-version-min=11']
+objc_args = ['-arch', 'arm64', '-mmacosx-version-min=11']
+c_link_args = ['-arch', 'arm64', '-mmacosx-version-min=11']
+cpp_link_args = ['-arch', 'arm64', '-mmacosx-version-min=11']
+objc_link_args = ['-arch', 'arm64', '-mmacosx-version-min=11']
 
 [host_machine]
 system = 'darwin'

--- a/scripts/meson-native-x86_64.ini
+++ b/scripts/meson-native-x86_64.ini
@@ -1,0 +1,7 @@
+[built-in options]
+c_args = ['-mmacosx-version-min=11']
+cpp_args = ['-mmacosx-version-min=11']
+objc_args = ['-mmacosx-version-min=11']
+c_link_args = ['-mmacosx-version-min=11']
+cpp_link_args = ['-mmacosx-version-min=11']
+objc_link_args = ['-mmacosx-version-min=11']


### PR DESCRIPTION
hopefully resolves warnings like

```
ld: warning: object file (/tmp/fcitx5/lib/libxkbcommon.a[9](src_xkbcomp_compat.c.o)) was built for newer 'macOS' version (13.0) than being linked (12.0)
```