### PR TITLE
lua: enable dlopen

### DIFF
--- a/scripts/lua.sh
+++ b/scripts/lua.sh
@@ -3,7 +3,7 @@ set -e
 cd lua
 
 make clean
-make a CFLAGS="-O3 -arch ${ARCH}"
+make a -j10 CFLAGS="-O3 -arch ${ARCH} -DLUA_USE_MACOSX"
 
 include_dir=$ROOT/build/lua$INSTALL_PREFIX/include
 lib_dir=$ROOT/build/lua$INSTALL_PREFIX/lib


### PR DESCRIPTION
<img width="1221" alt="image" src="https://github.com/fcitx-contrib/fcitx5-macos-prebuilder/assets/23358293/22214282-6ad6-44bd-946f-b34b34b5a4e0">

the fcitx5-rime plugin needs to be rebuilt as well.